### PR TITLE
We no longer need to move the debug python libs.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,13 +17,9 @@ build_script:
 
       vcpkg list --x-full-desc
 
-      # Merge debug output into root, where required
-      Set-Location C:\tools\vcpkg\installed
-      Move-Item "x86-windows-static-md\debug\lib\python27_d.*" "x86-windows-static-md\lib\"
-      Move-Item "x86-windows-static-md\debug\lib\python38_d.*" "x86-windows-static-md\lib\"
-
       # CURL's cmake modules are incompatible with Plasma, but CMake 3.17 tries
       # to use them anyway...  So we just nuke 'em
+      Set-Location C:\tools\vcpkg\installed
       Remove-Item "x86-windows-static-md\share\curl\CURL*.cmake"
 
       Set-Location C:\tools\vcpkg\installed\x86-windows-static-md


### PR DESCRIPTION
This was originally kept to be consistent with the move of the .dlls to a common bin dir, but we are building static libs now.  Furthermore, builds without vcpkg need to specify both the debug path and the non-debug path to get other debug libs anyway, a mechanism which continues to work for static Python as well.

For reference, the multiple paths should be used as follows:
```
> cmake "-DCMAKE_PREFIX_PATH=$DEVLIBS;$DEVLIBS/debug" [other parameters]
```